### PR TITLE
Verify Gemfile_next.lock is up-to-date

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -5,7 +5,7 @@
 # https://github.com/heroku/heroku-buildpack-ci-postgresql/blob/master/bin/compile
 
 # fail fast
-set -e
+#set -e
 
 # debug
 #set -x
@@ -36,7 +36,14 @@ function indent() {
 echo "-----> Installing Gemfile_next gems"
 cd $BUILD_DIR
 bundle_without="development:test"
+set -o pipefail # Enable pipefail so failure exit code from bundle install will not be lost by pipe to indent.
 BUNDLE_GEMFILE=Gemfile_next bundle install --without $bundle_without --path vendor/bundle --binstubs vendor/bundle/bin -j4 --deployment | indent
+bundle_install_status=$?
+set +o pipefail # Disable pipefail, only needed for above command as it is pipes to indent.
+
+if [ $bundle_install_status -ne 0 ]; then
+  error "bundle install error: This can happen when Gemfile_next.lock falls out of sync with Gemfile_next. Check the committed Gemfile_next.lock is up-to-date."
+fi
 
 echo "-----> Writing .profile.d/multiple-gemfiles.sh to run on dyno startup"
 mkdir -p .profile.d

--- a/bin/test-compile
+++ b/bin/test-compile
@@ -5,7 +5,7 @@
 # https://github.com/heroku/heroku-buildpack-ci-postgresql/blob/master/bin/compile
 
 # fail fast
-set -e
+#set -e
 
 # debug
 #set -x
@@ -38,7 +38,14 @@ function indent() {
 echo "-----> Installing Gemfile_next gems"
 cd $BUILD_DIR
 bundle_without="development"
+set -o pipefail # Enable pipefail so failure exit code from bundle install will not be lost by pipe to indent.
 BUNDLE_GEMFILE=Gemfile_next bundle install --without $bundle_without --path vendor/bundle --binstubs vendor/bundle/bin -j4 --deployment | indent
+bundle_install_status=$?
+set +o pipefail # Disable pipefail, only needed for above command as it is pipes to indent.
+
+if [ $bundle_install_status -ne 0 ]; then
+  error "bundle install error: This can happen when Gemfile_next.lock falls out of sync with Gemfile_next. Check the committed Gemfile_next.lock is up-to-date."
+fi
 
 echo "-----> Writing .profile.d/multiple-gemfiles.sh to run on dyno startup"
 mkdir -p .profile.d


### PR DESCRIPTION
Build will exit early with error when Gemfile_next.lock needs
updating. This usually happens after a gem has been updated/added
in Gemfile_common, but Gemfile_next.lock was not regenerated.